### PR TITLE
gpt3_5app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,7 +28,7 @@ def gen_auto_response(ques):
     openai.api_key=st.secrets["api"]
     
     response = openai.Completion.create(
-        model="code-cushman-001",
+        model="gpt-3.5-turbo",
         prompt=f""""Given a Python solution for the leetcode question below
                     {platform} Question: {ques}
                     {language} Solution: """,


### PR DESCRIPTION
in this patch i replaced the "code-crushman-001" to "gpt-3.5-turbo". As open AI has changed how it works with API KEYS and Has deleted older models like crushman-001, davinci-001 etc...

#Fix for streamlit web only (dunno how it behave on local machines.)